### PR TITLE
fix: use website_configuration instead of bucket config

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -442,7 +442,7 @@ class GraaspStack extends TerraformStack {
         this,
         `${id}-${website_name}`,
         website_name,
-        bucket.bucket.websiteEndpoint,
+        bucket.websiteConfiguration.websiteEndpoint,
         sslCertificateCloudfront,
         environment,
         !!bucket.websiteConfiguration,


### PR DESCRIPTION
This PR fixes a deprecation notice for `websiteEndpoint` on `bucket` we should now use the website configuration instead to get that `websiteEndpoint` value.