### PR TITLE
fix: allow communication between gatekeeper and meilisearch

### DIFF
--- a/constructs/gate_keeper.ts
+++ b/constructs/gate_keeper.ts
@@ -1,0 +1,56 @@
+import { TerraformVariable } from 'cdktf';
+
+import { Construct } from 'constructs';
+
+import { Vpc } from '../.gen/modules/vpc';
+import { Ec2 } from './ec2';
+
+export class GateKeeper extends Construct {
+  public instance: Ec2;
+
+  constructor(scope: Construct, name: string, vpc: Vpc) {
+    super(scope, `${name}-gatekeeper`);
+
+    const gatekeeperKeyName = new TerraformVariable(
+      scope,
+      'GRAASP_DB_GATEKEEPER_KEY_NAME',
+      {
+        nullable: false,
+        type: 'string',
+        description: 'Keyname for the keypair for graasp db gatekeeper',
+        sensitive: true,
+      },
+    );
+    const gatekeeperAmiId = new TerraformVariable(
+      scope,
+      'DB_GATEKEEPER_AMI_ID',
+      {
+        nullable: false,
+        type: 'string',
+        description: 'AMI id for graasp db gatekeeper',
+        sensitive: false,
+      },
+    );
+
+    const gatekeeperInstanceType = new TerraformVariable(
+      scope,
+      'DB_GATEKEEPER_INSTANCE_TYPE',
+      {
+        nullable: false,
+        type: 'string',
+        description: 'AMI instance type for graasp db gatekeeper',
+        sensitive: false,
+      },
+    );
+
+    this.instance = new Ec2(
+      this,
+      `${name}-gatekeeper`,
+      vpc,
+      gatekeeperKeyName,
+      gatekeeperAmiId.value,
+      gatekeeperInstanceType.value,
+      true,
+    );
+  }
+}

--- a/constructs/postgres.ts
+++ b/constructs/postgres.ts
@@ -40,13 +40,17 @@ export class PostgresDB extends Construct {
     if (gateKeeperSecurityGroup) {
       // Do not use the `ingress` and `egress` directly on the SecurityGroup for limitations reasons
       // See note on https://registry.terraform.io/providers/hashicorp/aws/5.16.1/docs/resources/security_group#protocol
-      new VpcSecurityGroupIngressRule(scope, `${name}-allow-gatekeeper`, {
-        referencedSecurityGroupId: gateKeeperSecurityGroup.id, // allowed source security group
-        fromPort: dbPort,
-        ipProtocol: 'tcp',
-        securityGroupId: dbSecurityGroup.id,
-        toPort: dbPort,
-      });
+      new VpcSecurityGroupIngressRule(
+        scope,
+        `${name}-allow-gatekeeper-on-postgres`,
+        {
+          referencedSecurityGroupId: gateKeeperSecurityGroup.id, // allowed source security group
+          fromPort: dbPort,
+          ipProtocol: 'tcp',
+          securityGroupId: dbSecurityGroup.id,
+          toPort: dbPort,
+        },
+      );
     }
 
     const defaultConfig: RdsConfig = {

--- a/constructs/security_group.ts
+++ b/constructs/security_group.ts
@@ -21,9 +21,10 @@ export function securityGroupOnlyAllowAnotherSecurityGroup(
 
   new VpcSecurityGroupIngressRule(scope, `${id}-allow-load-balancer`, {
     referencedSecurityGroupId: allowedSecurityGroupId, // allowed source security group
-    fromPort: port,
     ipProtocol: 'tcp',
     securityGroupId: securityGroup.id,
+    // port range, here we specify only a single port
+    fromPort: port,
     toPort: port,
   });
 

--- a/main.ts
+++ b/main.ts
@@ -160,14 +160,18 @@ class GraaspStack extends TerraformStack {
 
     const gatekeeper = new GateKeeper(this, 'graasp', vpc);
     // allow communication between the gatekeeper and meilisearch
-    new VpcSecurityGroupIngressRule(this, `${id}-allow-gatekeeper`, {
-      referencedSecurityGroupId: gatekeeper.instance.securityGroup.id, // allowed source security group
-      ipProtocol: 'tcp',
-      securityGroupId: meilisearchSecurityGroup.id,
-      // port range for ingress trafic
-      fromPort: MEILISEARCH_PORT,
-      toPort: MEILISEARCH_PORT,
-    });
+    new VpcSecurityGroupIngressRule(
+      this,
+      `${id}-allow-gatekeeper-on-meilisearch`,
+      {
+        referencedSecurityGroupId: gatekeeper.instance.securityGroup.id, // allowed source security group
+        ipProtocol: 'tcp',
+        securityGroupId: meilisearchSecurityGroup.id,
+        // port range for ingress trafic
+        fromPort: MEILISEARCH_PORT,
+        toPort: MEILISEARCH_PORT,
+      },
+    );
 
     new PostgresDB(
       this,


### PR DESCRIPTION
fix #30 

In this PR I move the gatekeeper configuration outside of the postgres service and add a rule to allow communicating from the gatekeeper to meilisearch with curl commands.

