### PR TITLE
feat: use redis as a container

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -26,6 +26,7 @@ export type GraaspConfiguration = {
     meilisearch: HardwareLimit;
     nudenet: HardwareLimit;
     iframely: HardwareLimit;
+    redis: HardwareLimit;
   };
 };
 
@@ -65,6 +66,10 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         cpu: '256',
         memory: '512',
       },
+      redis: {
+        cpu: '256',
+        memory: '512',
+      },
     },
   },
   [Environment.STAGING]: {
@@ -98,6 +103,10 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         cpu: '256',
         memory: '512',
       },
+      redis: {
+        cpu: '256',
+        memory: '512',
+      },
     },
   },
   [Environment.PRODUCTION]: {
@@ -128,6 +137,10 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         memory: '512',
       },
       iframely: {
+        cpu: '256',
+        memory: '512',
+      },
+      redis: {
         cpu: '256',
         memory: '512',
       },


### PR DESCRIPTION
In this PR, I setup redis as a container and remove the use of the Elasticache service in AWS. 

## Rational
Our use of redis is very sporadic, we use it for small caching tasks, but it is not an issue if the service looses data momentarily because of a reboot. 

The Elasticache AWS service is a high availability redis instance that should be used for caching requests, etc. We do not really have the use for it currently and a small container should be enough for our needs. The costs of the AWS managed service are not worth it currently. 