### PR TITLE
feat: add umami in infra

### DIFF
--- a/.github/workflows/infrastructure-deploy-dev-on-merge.yml
+++ b/.github/workflows/infrastructure-deploy-dev-on-merge.yml
@@ -1,4 +1,4 @@
-name: 'Apply Stack after PR is Merged'
+name: "Apply Stack after PR is Merged"
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   terraform:
-    name: 'Terraform CDK Diff'
+    name: "Terraform CDK Diff"
     environment: dev
     runs-on: ubuntu-latest
     steps:
@@ -52,6 +52,7 @@ jobs:
           TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
           TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
           TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+          TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
           TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
           TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
           TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/.github/workflows/infrastructure-deploy-env.yml
+++ b/.github/workflows/infrastructure-deploy-env.yml
@@ -1,16 +1,16 @@
-name: 'Apply infrastructure on env'
+name: "Apply infrastructure on env"
 
 on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Target environment'
+        description: "Target environment"
         type: environment
         required: true
 
 jobs:
   plan:
-    name: 'Terraform Plan (${{ inputs.environment }})'
+    name: "Terraform Plan (${{ inputs.environment }})"
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:
@@ -41,12 +41,13 @@ jobs:
           TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
           TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
           TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+          TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
           TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
           TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
           TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}
 
   deploy:
-    name: 'Deploy infra (${{ inputs.environment }})'
+    name: "Deploy infra (${{ inputs.environment }})"
     environment: ${{ inputs.environment }}
     needs: plan
     runs-on: ubuntu-latest
@@ -78,6 +79,7 @@ jobs:
           TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
           TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
           TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+          TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
           TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
           TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
           TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/.github/workflows/infrastructure-plan-on-pr.yml
+++ b/.github/workflows/infrastructure-plan-on-pr.yml
@@ -1,4 +1,4 @@
-name: 'Comment a Plan on a PR'
+name: "Comment a Plan on a PR"
 
 on: [pull_request]
 
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   terraform:
-    name: 'Terraform CDK Diff'
+    name: "Terraform CDK Diff"
     environment: dev
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +47,7 @@ jobs:
           TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
           TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
           TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+          TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
           TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
           TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
           TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/config.ts
+++ b/config.ts
@@ -72,8 +72,8 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         memory: '512',
       },
       umami: {
-        cpu: '256',
-        memory: '512',
+        cpu: '512',
+        memory: '1024',
       },
     },
   },
@@ -113,8 +113,8 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         memory: '512',
       },
       umami: {
-        cpu: '256',
-        memory: '512',
+        cpu: '512',
+        memory: '1024',
       },
     },
   },
@@ -154,8 +154,8 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         memory: '512',
       },
       umami: {
-        cpu: '256',
-        memory: '512',
+        cpu: '512',
+        memory: '1024',
       },
     },
   },

--- a/config.ts
+++ b/config.ts
@@ -27,6 +27,7 @@ export type GraaspConfiguration = {
     nudenet: HardwareLimit;
     iframely: HardwareLimit;
     redis: HardwareLimit;
+    umami: HardwareLimit;
   };
 };
 
@@ -70,6 +71,10 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         cpu: '256',
         memory: '512',
       },
+      umami: {
+        cpu: '256',
+        memory: '512',
+      },
     },
   },
   [Environment.STAGING]: {
@@ -107,6 +112,10 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         cpu: '256',
         memory: '512',
       },
+      umami: {
+        cpu: '256',
+        memory: '512',
+      },
     },
   },
   [Environment.PRODUCTION]: {
@@ -141,6 +150,10 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         memory: '512',
       },
       redis: {
+        cpu: '256',
+        memory: '512',
+      },
+      umami: {
         cpu: '256',
         memory: '512',
       },

--- a/constructs/cluster.ts
+++ b/constructs/cluster.ts
@@ -145,8 +145,8 @@ export class Cluster extends Construct {
           path: loadBalancerConfig.healthCheckPath,
           healthyThreshold: 5,
           unhealthyThreshold: 2,
-          timeout: 5,
-          interval: 30,
+          timeout: 6, // in seconds the response time after which the target is considered un-healthy
+          interval: 20, // in seconds (a very conservative value is 300, umami uses 5)
         },
       });
 
@@ -158,7 +158,7 @@ export class Cluster extends Construct {
         },
       ];
 
-      // Makes the listener forward requests from subpath to the target group
+      // Makes the listener forward requests from host to the target group
       new LbListenerRule(this, `${name}-rule`, {
         listenerArn: loadBalancerConfig.loadBalancer.lbl.arn,
         priority: loadBalancerConfig.priority,

--- a/constructs/cluster.ts
+++ b/constructs/cluster.ts
@@ -143,10 +143,10 @@ export class Cluster extends Construct {
         healthCheck: {
           enabled: true,
           path: loadBalancerConfig.healthCheckPath,
-          healthyThreshold: 5,
-          unhealthyThreshold: 2,
+          healthyThreshold: 3,
+          unhealthyThreshold: 3,
           timeout: 6, // in seconds the response time after which the target is considered un-healthy
-          interval: 20, // in seconds (a very conservative value is 300, umami uses 5)
+          interval: 60, // in seconds (a very conservative value is 300 to allow )
         },
       });
 

--- a/constructs/cluster.ts
+++ b/constructs/cluster.ts
@@ -146,7 +146,7 @@ export class Cluster extends Construct {
           healthyThreshold: 3,
           unhealthyThreshold: 3,
           timeout: 6, // in seconds the response time after which the target is considered un-healthy
-          interval: 60, // in seconds (a very conservative value is 300 to allow )
+          interval: 60, // in seconds
         },
       });
 

--- a/constructs/postgres.ts
+++ b/constructs/postgres.ts
@@ -8,7 +8,7 @@ import { Rds, RdsConfig } from '../.gen/modules/rds';
 import { Vpc } from '../.gen/modules/vpc';
 import {
   AllowedSecurityGroupInfo,
-  securityGroupOnlyAllowAnotherSecurityGroup,
+  securityGroupAllowMultipleOtherSecurityGroups,
 } from './security_group';
 
 export class PostgresDB extends Construct {
@@ -21,7 +21,7 @@ export class PostgresDB extends Construct {
     dbUsername: string,
     dbPassword: TerraformVariable,
     vpc: Vpc,
-    allowedSecurityGroup: AllowedSecurityGroupInfo,
+    allowedSecurityGroups: AllowedSecurityGroupInfo[],
     addReplica: boolean,
     backupRetentionPeriod: number,
     configOverride?: Partial<RdsConfig>,
@@ -31,11 +31,11 @@ export class PostgresDB extends Construct {
 
     const dbPort = 5432;
 
-    const dbSecurityGroup = securityGroupOnlyAllowAnotherSecurityGroup(
+    const dbSecurityGroup = securityGroupAllowMultipleOtherSecurityGroups(
       this,
       `${name}-db`,
       vpc.vpcIdOutput,
-      allowedSecurityGroup,
+      allowedSecurityGroups,
       dbPort,
     );
 

--- a/constructs/security_group.ts
+++ b/constructs/security_group.ts
@@ -39,6 +39,37 @@ export function securityGroupOnlyAllowAnotherSecurityGroup(
   return securityGroup;
 }
 
+export function securityGroupAllowMultipleOtherSecurityGroups(
+  scope: Construct,
+  id: string,
+  vpcId: string,
+  allowedSecurityGroups: AllowedSecurityGroupInfo[],
+  port: number,
+) {
+  const securityGroup = new SecurityGroup(scope, `${id}-security-group`, {
+    vpcId: vpcId,
+    name: id,
+    lifecycle: {
+      createBeforeDestroy: true, // see https://registry.terraform.io/providers/hashicorp/aws/5.16.1/docs/resources/security_group#recreating-a-security-group
+    },
+  });
+
+  for (const group of allowedSecurityGroups) {
+    new VpcSecurityGroupIngressRule(scope, `${id}-allow-${group.targetName}`, {
+      referencedSecurityGroupId: group.groupId, // allowed source security group
+      ipProtocol: 'tcp',
+      securityGroupId: securityGroup.id,
+      // port range, here we specify only a single port
+      fromPort: port,
+      toPort: port,
+    });
+  }
+
+  allowAllEgressRule(scope, id, securityGroup.id);
+
+  return securityGroup;
+}
+
 export function allowAllEgressRule(
   scope: Construct,
   id: string,

--- a/main.ts
+++ b/main.ts
@@ -57,7 +57,7 @@ class GraaspStack extends TerraformStack {
     const MEILISEARCH_PORT = 7700;
     const IFRAMELY_PORT = 8061;
     const REDIS_PORT = 6379;
-    const UMAMI_PORT = 8000;
+    const UMAMI_PORT = 3000;
 
     new AwsProvider(this, 'AWS', {
       region: environment.region,
@@ -412,7 +412,7 @@ class GraaspStack extends TerraformStack {
       [
         {
           hostPort: UMAMI_PORT,
-          containerPort: 3000,
+          containerPort: UMAMI_PORT,
         },
       ],
       {

--- a/main.ts
+++ b/main.ts
@@ -420,6 +420,7 @@ class GraaspStack extends TerraformStack {
         APP_SECRET:
           'a5b20f9ac88eb6d9c2a443664968052ee9f34a3ea8ed1ebe0c0d5c51d5ea78ca',
         DISABLE_TELEMETRY: '1',
+        HOSTNAME: '0.0.0.0', // needed for the app to bind to localhost, otherwise never answers the health-checks
       },
       environment,
     );

--- a/main.ts
+++ b/main.ts
@@ -57,6 +57,7 @@ class GraaspStack extends TerraformStack {
     const MEILISEARCH_PORT = 7700;
     const IFRAMELY_PORT = 8061;
     const REDIS_PORT = 6379;
+    const UMAMI_PORT = 8000;
 
     new AwsProvider(this, 'AWS', {
       region: environment.region,
@@ -117,11 +118,20 @@ class GraaspStack extends TerraformStack {
     );
 
     const cluster = new Cluster(this, id, vpc);
-    const loadBalancer = new LoadBalancer(
-      this,
-      id,
-      vpc,
-      sslCertificate,
+    const loadBalancer = new LoadBalancer(this, id, vpc, sslCertificate);
+
+    // ---- Setup redirections in the load-balancer -----
+    // for the go.graasp.org service, redirect to an api endpoint
+    loadBalancer.addListenerRuleForHostRedirect(
+      'shortener',
+      10,
+      {
+        subDomainOrigin: 'go', // requests from go.graasp.org
+        subDomainTarget: 'api', // to api.graasp.org
+        pathRewrite: '/items/short-links/#{path}', // rewrite the path to add the correct api route
+        // optionally keep query params
+        statusCode: 'HTTP_302', // temporary moved
+      },
       environment,
     );
 
@@ -151,6 +161,13 @@ class GraaspStack extends TerraformStack {
       loadBalancerAllowedSecurityGroupInfo,
       ETHERPAD_PORT,
     );
+    const umamiSecurityGroup = securityGroupOnlyAllowAnotherSecurityGroup(
+      this,
+      `${id}-umami`,
+      vpc.vpcIdOutput,
+      loadBalancerAllowedSecurityGroupInfo,
+      UMAMI_PORT,
+    );
 
     // define security groups accepting ingress trafic from the backend
     const backendAllowedSecurityGroupInfo = {
@@ -179,12 +196,28 @@ class GraaspStack extends TerraformStack {
       REDIS_PORT,
     );
 
+    const umamiAllowedSecurityGroupInfo = {
+      groupId: umamiSecurityGroup.id,
+      targetName: 'umami',
+    } satisfies AllowedSecurityGroupInfo;
+
     const dbPassword = new TerraformVariable(this, 'GRAASP_DB_PASSWORD', {
       nullable: false,
       type: 'string',
       description: 'Admin password for the graasp database',
       sensitive: true,
     });
+
+    const umamiDbUserPassword = new TerraformVariable(
+      this,
+      'UMAMI_DB_PASSWORD',
+      {
+        nullable: false,
+        type: 'string',
+        description: 'Umami user password for the postgresql database',
+        sensitive: true,
+      },
+    );
 
     const gatekeeper = new GateKeeper(this, id, vpc);
     // allow communication between the gatekeeper and meilisearch
@@ -201,14 +234,14 @@ class GraaspStack extends TerraformStack {
       },
     );
 
-    new PostgresDB(
+    const backendDb = new PostgresDB(
       this,
       id,
       'graasp',
       'graasp',
       dbPassword,
       vpc,
-      backendAllowedSecurityGroupInfo,
+      [backendAllowedSecurityGroupInfo, umamiAllowedSecurityGroupInfo],
       CONFIG[environment.env].dbConfig.graasp.enableReplication,
       CONFIG[environment.env].dbConfig.graasp.backupRetentionPeriod,
       undefined,
@@ -236,7 +269,7 @@ class GraaspStack extends TerraformStack {
       'graasp_etherpad',
       etherpadDbPassword,
       vpc,
-      etherpadAllowedSecurityGroupInfo,
+      [etherpadAllowedSecurityGroupInfo],
       false,
       CONFIG[environment.env].dbConfig.graasp.backupRetentionPeriod,
       {
@@ -372,6 +405,25 @@ class GraaspStack extends TerraformStack {
       environment,
     );
 
+    const umamiDefinition = createContainerDefinitions(
+      'umami',
+      'ghcr.io/umami-software/umami',
+      'postgresql-latest',
+      [
+        {
+          hostPort: UMAMI_PORT,
+          containerPort: 3000,
+        },
+      ],
+      {
+        DATABASE_URL: `postgresql://umami:${umamiDbUserPassword}@${backendDb.instance.dbInstanceAddressOutput}:5432/umami`,
+        APP_SECRET:
+          'a5b20f9ac88eb6d9c2a443664968052ee9f34a3ea8ed1ebe0c0d5c51d5ea78ca',
+        DISABLE_TELEMETRY: '1',
+      },
+      environment,
+    );
+
     // backend
     cluster.addService(
       'graasp',
@@ -393,7 +445,7 @@ class GraaspStack extends TerraformStack {
         host: subdomainForEnv('api', environment),
         port: 80,
         containerPort: BACKEND_PORT,
-        healthCheckPath: '/status',
+        healthCheckPath: '/health',
       },
     );
 
@@ -440,6 +492,28 @@ class GraaspStack extends TerraformStack {
         port: 443,
         containerPort: ETHERPAD_PORT,
         healthCheckPath: '/',
+      },
+    );
+
+    cluster.addService(
+      'umami',
+      1,
+      {
+        containerDefinitions: umamiDefinition,
+        cpu: CONFIG[environment.env].ecsConfig.umami.cpu,
+        memory: CONFIG[environment.env].ecsConfig.umami.memory,
+        dummy: false,
+      },
+      umamiSecurityGroup,
+      { name: 'umami', port: UMAMI_PORT },
+      undefined,
+      {
+        loadBalancer: loadBalancer,
+        priority: 4,
+        host: subdomainForEnv('umami', environment),
+        port: 80,
+        containerPort: UMAMI_PORT,
+        healthCheckPath: '/api/heartbeat',
       },
     );
 


### PR DESCRIPTION
Todo in each env: 
- [x] create the correct user with the right password in the database
  - [x] dev
  - [x] stage
  - [x] prod 
- [x] add the password environnement secret for umami in github
   - [x] done for DEV
   - [x] done for STAGE
   - [x] done for PROD

Open questions and things to check:
- [ ] hardwareLimits are enough ?
- [x] can ELB connect to the target ?
- [x] can umami connect to the db ?
- [x] do we need to add a silent redirection for the event send calls to work ? See https://github.com/graasp/graasp-account/pull/411
  - YES, the script is blocked by the browser because the cors headers are not present