### PR TITLE
feat: add spot instance config for ecs services

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,30 +1,61 @@
-import { Environment } from './utils';
+import {
+  Environment,
+  EnvironmentOptions,
+  SpotPreference,
+  SpotPreferenceOptions,
+} from './utils';
 
 export type HardwareLimit = {
   cpu: string;
   memory: string;
 };
 
+export type DeploymentTargetPreference = {
+  /**
+   * Container preference regarding choosing between spot instances (spare capacity, cheaper) or regular instances
+   *
+   * Recommended setting is: use OnlySpot for dev and maybe staging, in prod only use spot capacity for services that are stateless
+   * and fault tolerant.
+   *
+   * In production set `UpscaleWithSpot` for services that may auto-scale and for which it is OK to use spot capacity.
+   * A base instance **not** using spot capacity will always be used, while the next instances will use spot capacity
+   *
+   */
+  spotPreference?: SpotPreferenceOptions;
+};
+
+type ContainerConfig = HardwareLimit & DeploymentTargetPreference;
+
 export type GraaspConfiguration = {
   dbConfig: {
     graasp: {
+      /**
+       * Whether to enable database replication
+       */
       enableReplication: boolean;
-      backupRetentionPeriod: number; // day
+      /**
+       * Retention period in days
+       */
+      backupRetentionPeriod: number;
     };
   };
   ecsConfig: {
-    // library: HardwareLimit,
-    graasp: HardwareLimit & {
+    graasp: {
+      /**
+       * Desired number of tasks to run
+       */
       taskCount: number;
-    };
-    workers: HardwareLimit;
-    admin: HardwareLimit;
-    migrate: HardwareLimit;
-    etherpad: HardwareLimit;
-    meilisearch: HardwareLimit;
-    iframely: HardwareLimit;
-    redis: HardwareLimit;
-    umami: HardwareLimit;
+    } & ContainerConfig;
+    workers: ContainerConfig;
+    admin: ContainerConfig;
+    migrate: ContainerConfig;
+    etherpad: ContainerConfig;
+    meilisearch: ContainerConfig;
+    iframely: ContainerConfig;
+    redis: ContainerConfig;
+    umami: ContainerConfig;
+    // Library manages its own container definition
+    // library: ContainerConfig;
   };
 };
 
@@ -32,7 +63,7 @@ export type GraaspConfiguration = {
     This config represents the configuration option that might change between environment.
 */
 
-export const CONFIG: Record<Environment, GraaspConfiguration> = {
+export const CONFIG: Record<EnvironmentOptions, GraaspConfiguration> = {
   [Environment.DEV]: {
     dbConfig: {
       graasp: {
@@ -45,38 +76,47 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         cpu: '1024',
         memory: '2048',
         taskCount: 1,
+        spotPreference: SpotPreference.OnlySpot,
       },
       workers: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.OnlySpot,
       },
       admin: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.NoSpot,
       },
       migrate: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.OnlySpot,
       },
       etherpad: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.OnlySpot,
       },
       meilisearch: {
         cpu: '256',
         memory: '1024',
+        spotPreference: SpotPreference.NoSpot,
       },
       iframely: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.OnlySpot,
       },
       redis: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.NoSpot,
       },
       umami: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.OnlySpot,
       },
     },
   },
@@ -92,38 +132,47 @@ export const CONFIG: Record<Environment, GraaspConfiguration> = {
         cpu: '1024',
         memory: '2048',
         taskCount: 1,
+        spotPreference: SpotPreference.UpscaleWithSpot,
       },
       workers: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.UpscaleWithSpot,
       },
       admin: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.UpscaleWithSpot,
       },
       migrate: {
         cpu: '256',
         memory: '512',
+        spotPreference: SpotPreference.NoSpot,
       },
       etherpad: {
         cpu: '256',
         memory: '512',
+        // spotPreference: SpotPreference.NoSpot,
       },
       meilisearch: {
         cpu: '256',
         memory: '1024',
+        // spotPreference: SpotPreference.NoSpot,
       },
       iframely: {
         cpu: '256',
         memory: '512',
+        // spotPreference: SpotPreference.OnlySpot,
       },
       redis: {
         cpu: '256',
         memory: '512',
+        // spotPreference: SpotPreference.NoSpot,
       },
       umami: {
         cpu: '256',
         memory: '512',
+        // spotPreference: SpotPreference.NoSpot,
       },
     },
   },

--- a/constructs/cluster.ts
+++ b/constructs/cluster.ts
@@ -331,8 +331,10 @@ export class Cluster extends Construct {
       name,
       cluster: this.cluster.id,
       desiredCount: isActive ? desiredCount : 0,
+      // conflicts with capacityProviderStrategy, so should only be set if capacityProviderStrategy is not set
       launchType: capacityProviderStrategy ? undefined : 'FARGATE',
       capacityProviderStrategy,
+      forceNewDeployment: true,
       deploymentMinimumHealthyPercent: 100,
       deploymentMaximumPercent: 200,
       taskDefinition: task.arn,

--- a/constructs/cluster.ts
+++ b/constructs/cluster.ts
@@ -27,7 +27,11 @@ import { Fn, Token } from 'cdktf';
 import { Construct } from 'constructs';
 
 import { Vpc } from '../.gen/modules/vpc';
-import { EnvironmentConfig } from '../utils';
+import {
+  EnvironmentConfig,
+  SpotPreference,
+  SpotPreferenceOptions,
+} from '../utils';
 import { LoadBalancer } from './load_balancer';
 
 type PortMapping = { containerPort: number; hostPort: number };
@@ -54,14 +58,6 @@ type ContainerDefinition = {
     startPeriod: number;
   };
 };
-export const SpotPreferences = {
-  All: 'all',
-  Disabled: 'disabled',
-  Upscale: 'upscale',
-} as const;
-
-type SpotPreferencesOptions =
-  (typeof SpotPreferences)[keyof typeof SpotPreferences];
 
 type TaskDefinitionConfiguration = {
   containerDefinitions: ContainerDefinition[];
@@ -185,11 +181,14 @@ export class Cluster extends Construct {
   }
 
   private getCapacityProviderStrategy(
-    spotPreference: SpotPreferencesOptions,
+    spotPreference: SpotPreferenceOptions | undefined,
     desiredCount: number = 1,
-  ): EcsServiceCapacityProviderStrategy[] {
+  ): EcsServiceCapacityProviderStrategy[] | undefined {
+    if (!spotPreference) {
+      return undefined;
+    }
     switch (spotPreference) {
-      case SpotPreferences.Disabled:
+      case SpotPreference.NoSpot:
         return [
           {
             capacityProvider: 'FARGATE',
@@ -197,7 +196,7 @@ export class Cluster extends Construct {
             weight: 100,
           },
         ];
-      case SpotPreferences.Upscale:
+      case SpotPreference.UpscaleWithSpot:
         return [
           {
             capacityProvider: 'FARGATE',
@@ -208,7 +207,7 @@ export class Cluster extends Construct {
             capacityProvider: 'FARGATE_SPOT',
           },
         ];
-      case SpotPreferences.All:
+      case SpotPreference.OnlySpot:
         return [{ capacityProvider: 'FARGATE_SPOT', weight: 1 }];
     }
   }
@@ -226,10 +225,10 @@ export class Cluster extends Construct {
       taskRoleArn?: string;
       enableExecuteCommand?: boolean;
       // defines the preference for running on spot instances (cheaper)
-      // set to ' disabled' if it should not use spot instances at all
+      // set to 'disabled' if it should not use spot instances at all
       // set to 'upscale' if you would like to have one instance on standard and all other instances on spot
       // set to 'all' to use only spot instances (requires the service to be fault tolerant and stateless)
-      spotPreference: SpotPreferencesOptions;
+      spotPreference?: SpotPreferenceOptions;
     },
     taskDefinitionConfig: TaskDefinitionConfiguration,
     isActive: boolean,
@@ -332,6 +331,7 @@ export class Cluster extends Construct {
       name,
       cluster: this.cluster.id,
       desiredCount: isActive ? desiredCount : 0,
+      launchType: capacityProviderStrategy ? undefined : 'FARGATE',
       capacityProviderStrategy,
       deploymentMinimumHealthyPercent: 100,
       deploymentMaximumPercent: 200,

--- a/constructs/cluster.ts
+++ b/constructs/cluster.ts
@@ -6,8 +6,10 @@ import { AppautoscalingTarget } from '@cdktf/provider-aws/lib/appautoscaling-tar
 import { CloudwatchLogGroup } from '@cdktf/provider-aws/lib/cloudwatch-log-group';
 import { DataAwsEcsTaskExecution } from '@cdktf/provider-aws/lib/data-aws-ecs-task-execution';
 import { EcsCluster } from '@cdktf/provider-aws/lib/ecs-cluster';
+import { EcsClusterCapacityProviders } from '@cdktf/provider-aws/lib/ecs-cluster-capacity-providers';
 import {
   EcsService,
+  EcsServiceCapacityProviderStrategy,
   EcsServiceLoadBalancer,
 } from '@cdktf/provider-aws/lib/ecs-service';
 import { EcsTaskDefinition } from '@cdktf/provider-aws/lib/ecs-task-definition';
@@ -52,6 +54,15 @@ type ContainerDefinition = {
     startPeriod: number;
   };
 };
+export const SpotPreferences = {
+  All: 'all',
+  Disabled: 'disabled',
+  Upscale: 'upscale',
+} as const;
+
+type SpotPreferencesOptions =
+  (typeof SpotPreferences)[keyof typeof SpotPreferences];
+
 type TaskDefinitionConfiguration = {
   containerDefinitions: ContainerDefinition[];
   cpu?: string;
@@ -114,7 +125,6 @@ export class Cluster extends Construct {
 
     this.cluster = new EcsCluster(scope, `cluster`, { name });
     this.vpc = vpc;
-
     this.namespace = new ServiceDiscoveryHttpNamespace(this, 'namespace', {
       description: 'Namespace for internal communication between services',
       name: 'graasp',
@@ -160,6 +170,47 @@ export class Cluster extends Construct {
       ),
       role: this.executionRole.id,
     });
+    // setup cluster capacity providers (allows to use fargate spot)
+    new EcsClusterCapacityProviders(this, `${name}-ecs-capacity-providers`, {
+      clusterName: this.cluster.name,
+      capacityProviders: ['FARGATE_SPOT', 'FARGATE'],
+      defaultCapacityProviderStrategy: [
+        {
+          base: 1,
+          weight: 100,
+          capacityProvider: 'FARGATE',
+        },
+      ],
+    });
+  }
+
+  private getCapacityProviderStrategy(
+    spotPreference: SpotPreferencesOptions,
+    desiredCount: number = 1,
+  ): EcsServiceCapacityProviderStrategy[] {
+    switch (spotPreference) {
+      case SpotPreferences.Disabled:
+        return [
+          {
+            capacityProvider: 'FARGATE',
+            base: desiredCount,
+            weight: 100,
+          },
+        ];
+      case SpotPreferences.Upscale:
+        return [
+          {
+            capacityProvider: 'FARGATE',
+            base: 1,
+            weight: 1,
+          },
+          {
+            capacityProvider: 'FARGATE_SPOT',
+          },
+        ];
+      case SpotPreferences.All:
+        return [{ capacityProvider: 'FARGATE_SPOT', weight: 1 }];
+    }
   }
 
   public addService(
@@ -168,11 +219,17 @@ export class Cluster extends Construct {
       desiredCount,
       taskRoleArn,
       enableExecuteCommand,
+      spotPreference,
     }: {
       name: string;
       desiredCount: number;
       taskRoleArn?: string;
       enableExecuteCommand?: boolean;
+      // defines the preference for running on spot instances (cheaper)
+      // set to ' disabled' if it should not use spot instances at all
+      // set to 'upscale' if you would like to have one instance on standard and all other instances on spot
+      // set to 'all' to use only spot instances (requires the service to be fault tolerant and stateless)
+      spotPreference: SpotPreferencesOptions;
     },
     taskDefinitionConfig: TaskDefinitionConfiguration,
     isActive: boolean,
@@ -264,13 +321,18 @@ export class Cluster extends Construct {
       });
     }
 
-    // add service inside cluster
+    // define capacity provider strategy
+    const capacityProviderStrategy = this.getCapacityProviderStrategy(
+      spotPreference,
+      desiredCount,
+    );
 
+    // add service inside cluster
     const service = new EcsService(this, `${name}-service`, {
       name,
-      launchType: 'FARGATE',
       cluster: this.cluster.id,
       desiredCount: isActive ? desiredCount : 0,
+      capacityProviderStrategy,
       deploymentMinimumHealthyPercent: 100,
       deploymentMaximumPercent: 200,
       taskDefinition: task.arn,

--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,11 @@ import {
   createMaintenanceFunction,
   makeCloudfront,
 } from './constructs/cloudfront';
-import { Cluster, createContainerDefinitions } from './constructs/cluster';
+import {
+  Cluster,
+  SpotPreferences,
+  createContainerDefinitions,
+} from './constructs/cluster';
 import { createDNSEntry } from './constructs/dns';
 import { GateKeeper } from './constructs/gate_keeper';
 import { LoadBalancer } from './constructs/load_balancer';
@@ -982,6 +986,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'graasp',
         desiredCount: CONFIG[environment.env].ecsConfig.graasp.taskCount,
+        spotPreference: SpotPreferences.Upscale,
       },
       {
         containerDefinitions: [coreDefinition, nudenetDefinition],
@@ -1054,6 +1059,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'workers',
         desiredCount: 1,
+        spotPreference: SpotPreferences.All,
       },
       {
         containerDefinitions: [workersDefinition],
@@ -1080,6 +1086,7 @@ class GraaspStack extends TerraformStack {
         desiredCount: 1,
         taskRoleArn: adminTaskRole.role.arn,
         enableExecuteCommand: true,
+        spotPreference: SpotPreferences.Upscale,
       },
       {
         containerDefinitions: [adminDefinition],
@@ -1112,6 +1119,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'graasp-library',
         desiredCount: 1,
+        spotPreference: SpotPreferences.Upscale,
       },
       { containerDefinitions: [libraryDefinition] },
       graaspServicesActive,
@@ -1141,6 +1149,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'etherpad',
         desiredCount: 1,
+        spotPreference: SpotPreferences.Upscale,
       },
       {
         containerDefinitions: [etherpadDefinition],
@@ -1167,6 +1176,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'umami',
         desiredCount: 1,
+        spotPreference: SpotPreferences.Disabled,
       },
       {
         containerDefinitions: [umamiDefinition],
@@ -1197,6 +1207,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'meilisearch',
         desiredCount: 1,
+        spotPreference: SpotPreferences.Disabled,
       },
       {
         containerDefinitions: [meilisearchDefinition],
@@ -1212,6 +1223,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'iframely',
         desiredCount: 1,
+        spotPreference: SpotPreferences.All,
       },
       {
         containerDefinitions: [iframelyDefinition],
@@ -1227,6 +1239,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'redis',
         desiredCount: 1,
+        spotPreference: SpotPreferences.Disabled,
       },
       {
         containerDefinitions: [redisDefinition],

--- a/main.ts
+++ b/main.ts
@@ -23,11 +23,7 @@ import {
   createMaintenanceFunction,
   makeCloudfront,
 } from './constructs/cloudfront';
-import {
-  Cluster,
-  SpotPreferences,
-  createContainerDefinitions,
-} from './constructs/cluster';
+import { Cluster, createContainerDefinitions } from './constructs/cluster';
 import { createDNSEntry } from './constructs/dns';
 import { GateKeeper } from './constructs/gate_keeper';
 import { LoadBalancer } from './constructs/load_balancer';
@@ -43,7 +39,9 @@ import {
   AllowedRegion,
   Environment,
   EnvironmentConfig,
+  EnvironmentOptions,
   GraaspWebsiteConfig,
+  SpotPreference,
   buildPostgresConnectionString,
   envCorsRegex,
   envDomain,
@@ -61,7 +59,7 @@ const CERTIFICATE_REGION = 'us-east-1';
 
 const SHARED_TAGS = { 'terraform-managed': 'true' };
 
-const ROLE_BY_ENV: Record<Environment, AwsProviderAssumeRole[]> = {
+const ROLE_BY_ENV: Record<EnvironmentOptions, AwsProviderAssumeRole[]> = {
   [Environment.DEV]: [{ roleArn: 'arn:aws:iam::299720865162:role/terraform' }],
 
   [Environment.PRODUCTION]: [
@@ -986,7 +984,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'graasp',
         desiredCount: CONFIG[environment.env].ecsConfig.graasp.taskCount,
-        spotPreference: SpotPreferences.Upscale,
+        spotPreference: CONFIG[environment.env].ecsConfig.graasp.spotPreference,
       },
       {
         containerDefinitions: [coreDefinition, nudenetDefinition],
@@ -1059,7 +1057,8 @@ class GraaspStack extends TerraformStack {
       {
         name: 'workers',
         desiredCount: 1,
-        spotPreference: SpotPreferences.All,
+        spotPreference:
+          CONFIG[environment.env].ecsConfig.workers.spotPreference,
       },
       {
         containerDefinitions: [workersDefinition],
@@ -1086,7 +1085,7 @@ class GraaspStack extends TerraformStack {
         desiredCount: 1,
         taskRoleArn: adminTaskRole.role.arn,
         enableExecuteCommand: true,
-        spotPreference: SpotPreferences.Upscale,
+        spotPreference: CONFIG[environment.env].ecsConfig.admin.spotPreference,
       },
       {
         containerDefinitions: [adminDefinition],
@@ -1119,7 +1118,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'graasp-library',
         desiredCount: 1,
-        spotPreference: SpotPreferences.Upscale,
+        spotPreference: SpotPreference.UpscaleWithSpot,
       },
       { containerDefinitions: [libraryDefinition] },
       graaspServicesActive,
@@ -1149,7 +1148,8 @@ class GraaspStack extends TerraformStack {
       {
         name: 'etherpad',
         desiredCount: 1,
-        spotPreference: SpotPreferences.Upscale,
+        spotPreference:
+          CONFIG[environment.env].ecsConfig.etherpad.spotPreference,
       },
       {
         containerDefinitions: [etherpadDefinition],
@@ -1176,7 +1176,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'umami',
         desiredCount: 1,
-        spotPreference: SpotPreferences.Disabled,
+        spotPreference: CONFIG[environment.env].ecsConfig.umami.spotPreference,
       },
       {
         containerDefinitions: [umamiDefinition],
@@ -1207,7 +1207,8 @@ class GraaspStack extends TerraformStack {
       {
         name: 'meilisearch',
         desiredCount: 1,
-        spotPreference: SpotPreferences.Disabled,
+        spotPreference:
+          CONFIG[environment.env].ecsConfig.meilisearch.spotPreference,
       },
       {
         containerDefinitions: [meilisearchDefinition],
@@ -1223,7 +1224,8 @@ class GraaspStack extends TerraformStack {
       {
         name: 'iframely',
         desiredCount: 1,
-        spotPreference: SpotPreferences.All,
+        spotPreference:
+          CONFIG[environment.env].ecsConfig.iframely.spotPreference,
       },
       {
         containerDefinitions: [iframelyDefinition],
@@ -1239,7 +1241,7 @@ class GraaspStack extends TerraformStack {
       {
         name: 'redis',
         desiredCount: 1,
-        spotPreference: SpotPreferences.Disabled,
+        spotPreference: CONFIG[environment.env].ecsConfig.redis.spotPreference,
       },
       {
         containerDefinitions: [redisDefinition],

--- a/utils.ts
+++ b/utils.ts
@@ -5,10 +5,11 @@ import { S3BucketObjectOwnership } from './constructs/bucket';
 
 export const GRAASP_ROOT_DOMAIN = 'graasp.org';
 
-export enum Environment {
-  DEV,
-  PRODUCTION,
-}
+export const Environment = {
+  DEV: 'dev',
+  PRODUCTION: 'production',
+} as const;
+export type EnvironmentOptions = (typeof Environment)[keyof typeof Environment];
 
 export const AllowedRegion = {
   Frankfurt: 'eu-central-1',
@@ -40,8 +41,17 @@ const InfraState = {
 } as const;
 export type InfraStateOptions = (typeof InfraState)[keyof typeof InfraState];
 
+export const SpotPreference = {
+  OnlySpot: 'OnlySpot',
+  NoSpot: 'NoSpot',
+  UpscaleWithSpot: 'UpscaleWithSpot',
+} as const;
+
+export type SpotPreferenceOptions =
+  (typeof SpotPreference)[keyof typeof SpotPreference];
+
 export type EnvironmentConfig = {
-  env: Environment;
+  env: EnvironmentOptions;
   subdomain?: string;
   region: AllowedRegionOptions;
   infraState: InfraStateOptions;


### PR DESCRIPTION
**TLDR**: In this PR I add support for defining spot instance preferences.


## Context 

Spot instances are an AWS feature that allows to run you workloads on spare capacity (understand servers that are currently not in use). In order to utilise this idling capacity, AWS makes it available under the `FARGATE_SPOT` capacity provider. You can reduce costs by up to 70% by using spare capacity.

There are however some caveats to be aware of:
- spare capacity can be reclaimed by AWS anytime with a **2 min notice**, after that notice the container is killed
- the capacity is **not guaranteed**, so your container might not start immediately

Knowing this, we can however take advantage of this opportunity for workloads that are **stateless** and **fault tolerant** since after making a reclaim notice, fargate will try to find a new capacity to launch your workload. In ideal cases your workload can run without interruption. 

It is **not recommended**  to use spot instances for your core application in Production. However it is fine to use it in stage or development environments. 

## What this PR does

In this PR I add a way to define spot preference for each container and depending on the environnement.

The basic plan is that in Production only `iframely` is deployed using exclusively spot capacity. Since other services are either stateful (meilisearch), or only deployed as a single task (etherpad, redis, umami, etc) they need to be reliable. the backend uses an alternative strategy: it is always deployed with a base container on the "classic" on-demand target and additional tasks are deployed using spot capacity. This provides a cost effective service while being able to absorb trafic in cases of spikes.

In Stating we use a similar strategy to prod.

In dev all containers are deployed using spot strategy, excluding `meilisearch` and `redis`. 