### PR TITLE
feat: add scheduled workflow to delete untagged ECR images

### DIFF
--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -5,18 +5,44 @@ on:
   schedule:
     - cron: "58 1 * * *" # runs everyday at 1:58AM
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
 jobs:
   cleanup:
     strategy:
       matrix:
-        environment: ["dev"] # add staging and prod later
+        environment: ["dev"] # , "staging", "prod"
         repository: ["graasp", "graasp/explore"]
-    name: Cleanup images in ECR
+    name: Cleanup ${{ matrix.repository }} on ${{ matrix.environment }}
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
 
     steps:
-      - run: echo hello
-      # - uses: ./.github/actions/delete-untagged-ecr-images
-      #   with:
-      #     repository: ${{ matrix.repository }}
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-session-name: manageECRactionJob
+          aws-region: ${{ vars.AWS_REGION }}
+
+        # Get ECR images from current repo (defined in the matrix strategy) that are **untagged**
+        # These images are not needed anymore and get be deleted
+        # The second line formats the output to extract the imageDigest as a list of space separated values suitable for further treatment
+      - name: Get images
+        run: |
+          untagged_images=$(aws ecr list-images --repository-name ${{ matrix.repository }} --filter tagStatus=UNTAGGED)
+          echo "IMAGE_DIGESTS=$(echo $untagged_images | jq -r '.imageIds | map("imageDigest=\(.imageDigest)") | join(" ")')" >> $GITHUB_ENV
+
+        # Delete the images that have no tag (from the previous step)
+        # We batch delete these images and then print a summary message for the CI.
+      - name: Delete images
+        if: ${{ env.IMAGE_DIGESTS != '' }}
+        run: |
+          result=$(aws ecr batch-delete-image --repository-name ${{ matrix.repository }} --image-ids ${{ env.IMAGE_DIGESTS }})
+          echo $result
+          echo $result | jq -r '"Deleted \(.imageIds | length) images, failed to delete \(.failures | length) images."' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -31,7 +31,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
         # Get ECR images from current repo (defined in the matrix strategy) that are **untagged**
-        # These images are not needed anymore and get be deleted
+        # These images are not needed anymore and can be deleted
         # The second line formats the output to extract the imageDigest as a list of space separated values suitable for further treatment
       - name: Get images
         run: |


### PR DESCRIPTION
In this PR I add a workflow that removes untagged images from ECR on a schedule:

It uses the OIDC method to get a token to impersonate a role in AWS. The role is allowed to manage ECR.
It runs a matrix strategy for all envs (dev, staging, prod) and all repositories (graasp, graasp/explore).
It fetches the imageDigests of all ECR images that are not tagged.
It deletes these images.
It prints a summary of the number of images it has deleted with success or failure. ✨ 

Refs:
[OIDC with AWS and Github](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
[Remove images from ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/delete_image.html)
[Matrix strategy in github actions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#example-using-a-multi-dimension-matrix)