### PR TITLE
fix: db start issues

### DIFF
--- a/.github/actions/prepare-terraform/action.yml
+++ b/.github/actions/prepare-terraform/action.yml
@@ -2,11 +2,17 @@ name: Composite cdktf workflow
 description: Runs a plan or deploy action for terraform cdktf
 
 inputs:
-  aws-access-key-id:
-    description: "AWS Key id"
+  # aws-access-key-id:
+  #   description: "AWS Key id"
+  #   required: true
+  # aws-secret-access-key:
+  #   description: "AWS secret key"
+  #   required: true
+  role-to-assume:
+    description: "AWS role to assume"
     required: true
-  aws-secret-access-key:
-    description: "AWS secret key"
+  aws-region:
+    description: "AWS region"
     required: true
 
 runs:
@@ -30,10 +36,11 @@ runs:
       id: configure-aws
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
-        aws-region: eu-central-2 # not really important because it is reconfigured by Terraform
-
+        role-to-assume: ${{ inputs.role-to-assume }}
+        role-session-name: GitHub_Action_deploy_infrastructure
+        # aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        # aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
 
     # deploy: run: npx cdktf deploy --auto-approve 'graasp-${{ inputs.environment }}'
     # with the same variables

--- a/.github/actions/prepare-terraform/action.yml
+++ b/.github/actions/prepare-terraform/action.yml
@@ -2,14 +2,11 @@ name: Composite cdktf workflow
 description: Runs a plan or deploy action for terraform cdktf
 
 inputs:
-  # aws-access-key-id:
-  #   description: "AWS Key id"
-  #   required: true
-  # aws-secret-access-key:
-  #   description: "AWS secret key"
-  #   required: true
-  role-to-assume:
-    description: "AWS role to assume"
+  aws-access-key-id:
+    description: "AWS Key id"
+    required: true
+  aws-secret-access-key:
+    description: "AWS secret key"
     required: true
   aws-region:
     description: "AWS region"
@@ -36,11 +33,6 @@ runs:
       id: configure-aws
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ inputs.role-to-assume }}
-        role-session-name: GitHub_Action_deploy_infrastructure
-        # aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        # aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ inputs.aws-region }}
-
-    # deploy: run: npx cdktf deploy --auto-approve 'graasp-${{ inputs.environment }}'
-    # with the same variables

--- a/.github/workflows/delete-untagged-images.yml
+++ b/.github/workflows/delete-untagged-images.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}
           role-session-name: manageECRactionJob
           aws-region: ${{ vars.AWS_REGION }}
 

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare terraform
-        uses: ./.github/actions/prepare-terraform
+      - name: Configure AWS Credentials
+        id: configure-aws
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}
+          role-session-name: GitHub_Action_deploy_infrastructure
           aws-region: ${{ vars.AWS_REGION }}
-        #   aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
-        #   aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
       - name: Start DB
         if: ${{ env.state != 'stopped' }}
@@ -62,6 +62,13 @@ jobs:
             echo "waiting for DB to be down $(date -u +%H:%M:%S) (UTC)"
             sleep 30
           done
+
+      - name: Prepare terraform
+        uses: ./.github/actions/prepare-terraform
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
       - name: Deploy
         run: npx cdktf deploy --auto-approve 'graasp-${{ env.environment }}'

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   deploy:
-    name: "Deploy infra in ${{ env.state }} state to ${{ env.environment || 'dev' }} environment"
+    name: "Deploy infra in running state to ${{ inputs.environment || 'dev' }} environment"
+    environment: ${{ inputs.environment || 'dev' }}
     env:
       state: "running"
       environment: ${{ inputs.environment || 'dev' }}
-    environment: ${{ env.environment }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -30,10 +30,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
       - name: Start DB
-        if: ${{ env.state != "stopped" }}
+        if: ${{ env.state != 'stopped' }}
         run: |
           aws rds start-db-instance graasp-${{ env.environment }}
-          while [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") != "running"]
+          while [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") != "running" ]
           do
             echo "waiting for DB to be up ${date -u +%H:%M:%S\(UTC\)}"
             sleep 30

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -48,6 +48,7 @@ jobs:
             echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
             sleep 30
           done
+          echo "DB successfully started!"
 
       - name: Stop DB
         if: ${{ env.state == 'stopped' }}
@@ -62,6 +63,7 @@ jobs:
             echo "waiting for DB to be down $(date -u +%H:%M:%S) (UTC)"
             sleep 30
           done
+          echo "DB successfully stopped!"
 
       - name: Prepare terraform
         uses: ./.github/actions/prepare-terraform

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Start DB
         if: ${{ env.state != 'stopped' }}
         run: |
+          aws sts get-caller-identity
           aws rds start-db-instance --db-instance-identifier graasp-${{ env.environment }}
           while [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") != "running" ]
           do

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Start DB
         if: ${{ env.state != 'stopped' }}
         run: |
-          aws rds start-db-instance graasp-${{ env.environment }}
+          aws rds start-db-instance --db-instance-identifier graasp-${{ env.environment }}
           while [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") != "running" ]
           do
             echo "waiting for DB to be up ${date -u +%H:%M:%S\(UTC\)}"

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -10,6 +10,10 @@ on:
         type: environment
         required: true
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
 jobs:
   deploy:
     name: "Deploy infra in running state to ${{ inputs.environment || 'dev' }} environment"
@@ -26,19 +30,38 @@ jobs:
       - name: Prepare terraform
         uses: ./.github/actions/prepare-terraform
         with:
-          aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+        #   aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
+        #   aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
       - name: Start DB
         if: ${{ env.state != 'stopped' }}
         run: |
-          aws sts get-caller-identity
-          aws rds start-db-instance --db-instance-identifier graasp-${{ env.environment }}
-          while [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") != "running" ]
+          # start the db if it is in a "stopped" state
+          if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
+          then
+            aws rds start-db-instance --db-instance-identifier graasp-${{ env.environment }}
+          fi
+          while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
           do
-            echo "waiting for DB to be up ${date -u +%H:%M:%S\(UTC\)}"
+            echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
             sleep 30
-          end
+          done
+
+      - name: Stop DB
+        if: ${{ env.state == 'stopped' }}
+        run: |
+          # stop the db if it is in the "available" state
+          if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "available" ]
+          then
+            aws rds stop-db-instance --db-instance-identifier graasp-${{ env.environment }}
+          fi
+          while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "stopped" ]
+          do
+            echo "waiting for DB to be down $(date -u +%H:%M:%S) (UTC)"
+            sleep 30
+          done
 
       - name: Deploy
         run: npx cdktf deploy --auto-approve 'graasp-${{ env.environment }}'

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -1,30 +1,24 @@
-name: Start Infra
+name: Auto-start dev infra
 on:
   schedule:
     - cron: "30 7 * * *"
+  # allow to start infra of another env manually
   workflow_dispatch:
     inputs:
       environment:
         description: "Target environment"
         type: environment
         required: true
-      state:
-        description: "Expected infrastructure state"
-        type: choice
-        options:
-          - running
-          - restricted
-          - db-only
-          - stopped
-        required: false
-        # default to running - only for the manual select
-        default: running
 
 jobs:
   deploy:
-    name: "Deploy infra in ${{ inputs.state || 'running' }} state to ${{ inputs.environment || 'dev' }} environment"
-    environment: ${{ inputs.environment || 'dev' }}
+    name: "Deploy infra in ${{ env.state }} state to ${{ env.environment || 'dev' }} environment"
+    env:
+      state: "running"
+      environment: ${{ inputs.environment || 'dev' }}
+    environment: ${{ env.environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,11 +29,21 @@ jobs:
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
+      - name: Start DB
+        if: ${{ env.state != "stopped" }}
+        run: |
+          aws rds start-db-instance graasp-${{ env.environment }}
+          while [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") != "running"]
+          do
+            echo "waiting for DB to be up ${date -u +%H:%M:%S\(UTC\)}"
+            sleep 30
+          end
+
       - name: Deploy
-        run: npx cdktf deploy --auto-approve 'graasp-${{ inputs.environment || 'dev' }}'
+        run: npx cdktf deploy --auto-approve 'graasp-${{ env.environment }}'
         shell: bash
         env:
-          INFRA_STATE: ${{ inputs.state || 'running' }}
+          INFRA_STATE: ${{ env.state }}
           MAINTENANCE_HEADER_NAME: ${{ secrets.MAINTENANCE_HEADER_NAME }}
           MAINTENANCE_HEADER_SECRET: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
           TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}

--- a/.github/workflows/infra-stop.yml
+++ b/.github/workflows/infra-stop.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Prepare terraform
         uses: ./.github/actions/prepare-terraform
         with:
+          aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 

--- a/.github/workflows/infrastructure-deploy-dev-on-merge.yml
+++ b/.github/workflows/infrastructure-deploy-dev-on-merge.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Prepare terraform
         uses: ./.github/actions/prepare-terraform
         with:
+          aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 

--- a/.github/workflows/infrastructure-deploy-env.yml
+++ b/.github/workflows/infrastructure-deploy-env.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Prepare terraform
         uses: ./.github/actions/prepare-terraform
         with:
+          aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
@@ -61,6 +62,7 @@ jobs:
       - name: Prepare terraform
         uses: ./.github/actions/prepare-terraform
         with:
+          aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 

--- a/.github/workflows/infrastructure-deploy-env.yml
+++ b/.github/workflows/infrastructure-deploy-env.yml
@@ -8,7 +8,7 @@ on:
         type: environment
         required: true
       state:
-        description: "Expected infrastructure running, active, restricted, db-only or stopped"
+        description: "Expected infrastructure state"
         type: choice
         options:
           - running
@@ -16,6 +16,7 @@ on:
           - db-only
           - stopped
         required: false
+        # default to running
         default: running
 
 jobs:

--- a/.github/workflows/infrastructure-plan-on-pr.yml
+++ b/.github/workflows/infrastructure-plan-on-pr.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Prepare terraform
         uses: ./.github/actions/prepare-terraform
         with:
+          aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 


### PR DESCRIPTION
In this PR I fix some issues mainly related to how long the database can take to start and the apparent issues terraform has to ensure it is started.

To mitigate these issues I:
- added a manual step in the workflow, that starts and stops the DB and waits for it to be in the desired state.
- Use the OIDC auth to assume the terraform role which is the only way to have the rights to opperate on the db
  - this caused some issues as the infra deploy expects to be able to also assume this role, but then, the credentials available are the ones from the role, so it fails. To solve this, I log a second time after starting the DB, only as the terraform **user**.
- since the new workflow can potentially wait for an infinite time, I added a timeout of **45min** to ensure it does not run for days. 
- added the aws region from the env in the aws login action