### PR TITLE
feat: composite deploy with state

### DIFF
--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -26,25 +26,25 @@ inputs:
   maintenance-header-secret:
     description: "Maintenance header value"
     required: true
-  tf-var-meilisearch-master-key:
+  meilisearch-master-key:
     description: "Meilisearch master key"
     required: true
-  tf-var-graasp-db-password:
+  graasp-db-password:
     description: "Graasp DB password"
     required: true
-  tf-var-etherpad-db-password:
+  etherpad-db-password:
     description: "Etherpad DB password"
     required: true
-  tf-var-umami-db-password:
+  umami-db-password:
     description: "Umami DB password"
     required: true
-  tf-var-graasp-db-gatekeeper-key-name:
+  graasp-db-gatekeeper-key-name:
     description: "Gatekeeper key name for auth"
     required: true
-  tf-var-db-gatekeeper-ami-id:
+  gatekeeper-ami-id:
     description: "Gatekeeper AMI for machine setup"
     required: true
-  tf-var-db-gatekeeper-instance-type:
+  gatekeeper-instance-type:
     description: "Gatekeeper instance type"
     required: true
 
@@ -122,10 +122,10 @@ runs:
         INFRA_STATE: ${{ inputs.state }}
         MAINTENANCE_HEADER_NAME: ${{ inputs.maintenance-header-name }}
         MAINTENANCE_HEADER_SECRET: ${{ inputs.maintenance-header-secret }}
-        TF_VAR_MEILISEARCH_MASTER_KEY: ${{ inputs.tf-meilisearch-master-key }}
-        TF_VAR_GRAASP_DB_PASSWORD: ${{ inputs.tf-graasp-db-password }}
-        TF_VAR_ETHERPAD_DB_PASSWORD: ${{ inputs.tf-etherpad-db-password }}
-        TF_VAR_UMAMI_DB_PASSWORD: ${{ inputs.tf-var-umami-db-password }}
-        TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ inputs.tf-graasp-db-gatekeeper-key-name }}
-        TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ inputs.tf-db-gatekeeper-ami-id }}
-        TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ inputs.tf-db-gatekeeper-instance-type }}
+        TF_VAR_MEILISEARCH_MASTER_KEY: ${{ inputs.meilisearch-master-key }}
+        TF_VAR_GRAASP_DB_PASSWORD: ${{ inputs.graasp-db-password }}
+        TF_VAR_ETHERPAD_DB_PASSWORD: ${{ inputs.etherpad-db-password }}
+        TF_VAR_UMAMI_DB_PASSWORD: ${{ inputs.umami-db-password }}
+        TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ inputs.graasp-db-gatekeeper-key-name }}
+        TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ inputs.gatekeeper-ami-id }}
+        TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ inputs.gatekeeper-instance-type }}

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -63,7 +63,7 @@ runs:
       shell: bash
       run: |
         # start the db if it is in a "stopped" state
-        if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
+        if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
         then
           aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }}
         fi
@@ -79,7 +79,7 @@ runs:
       shell: bash
       run: |
         # stop the db if it is in the "available" state
-        if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "available" ]
+        if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "available" ]
         then
           aws rds stop-db-instance --db-instance-identifier graasp-${{ inputs.environment }}
         fi

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -51,44 +51,44 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Configure AWS Credentials to assume terraform Role
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ inputs.aws-role-to-assume }}
-        role-session-name: GitHub_Action_deploy_infrastructure
-        aws-region: ${{ inputs.aws-region }}
+    # - name: Configure AWS Credentials to assume terraform Role
+    #   uses: aws-actions/configure-aws-credentials@v4
+    #   with:
+    #     role-to-assume: ${{ inputs.aws-role-to-assume }}
+    #     role-session-name: GitHub_Action_deploy_infrastructure
+    #     aws-region: ${{ inputs.aws-region }}
 
-    - name: Start DB
-      if: ${{ inputs.state != 'stopped' }}
-      shell: bash
-      run: |
-        # start the db if it is in a "stopped" state
-        if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
-        then
-          aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
-        fi
-        while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
-        do
-          echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
-          sleep 30
-        done
-        echo "DB successfully started!"
+    # - name: Start DB
+    #   if: ${{ inputs.state != 'stopped' }}
+    #   shell: bash
+    #   run: |
+    #     # start the db if it is in a "stopped" state
+    #     if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
+    #     then
+    #       aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
+    #     fi
+    #     while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
+    #     do
+    #       echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
+    #       sleep 30
+    #     done
+    #     echo "DB successfully started!"
 
-    - name: Stop DB
-      if: ${{ inputs.state == 'stopped' }}
-      shell: bash
-      run: |
-        # stop the db if it is in the "available" state
-        if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "available" ]
-        then
-          aws rds stop-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
-        fi
-        while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "stopped" ]
-        do
-          echo "waiting for DB to be down $(date -u +%H:%M:%S) (UTC)"
-          sleep 30
-        done
-        echo "DB successfully stopped!"
+    # - name: Stop DB
+    #   if: ${{ inputs.state == 'stopped' }}
+    #   shell: bash
+    #   run: |
+    #     # stop the db if it is in the "available" state
+    #     if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "available" ]
+    #     then
+    #       aws rds stop-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
+    #     fi
+    #     while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "stopped" ]
+    #     do
+    #       echo "waiting for DB to be down $(date -u +%H:%M:%S) (UTC)"
+    #       sleep 30
+    #     done
+    #     echo "DB successfully stopped!"
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -24,9 +24,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
     - name: Configure AWS Credentials to assume terraform Role
       id: configure-aws-assume-role
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -51,28 +51,30 @@ inputs:
 runs:
   using: composite
   steps:
-    # - name: Configure AWS Credentials to assume terraform Role
-    #   uses: aws-actions/configure-aws-credentials@v4
-    #   with:
-    #     role-to-assume: ${{ inputs.aws-role-to-assume }}
-    #     role-session-name: GitHub_Action_deploy_infrastructure
-    #     aws-region: ${{ inputs.aws-region }}
+    - name: Configure AWS Credentials to assume terraform Role
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        role-session-name: GitHub_Action_deploy_infrastructure
+        aws-region: ${{ inputs.aws-region }}
 
-    # - name: Start DB
-    #   if: ${{ inputs.state != 'stopped' }}
-    #   shell: bash
-    #   run: |
-    #     # start the db if it is in a "stopped" state
-    #     if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
-    #     then
-    #       aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
-    #     fi
-    #     while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
-    #     do
-    #       echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
-    #       sleep 30
-    #     done
-    #     echo "DB successfully started!"
+    # This is a hack because there is a bug in the Terraform AWS provider where it is not possible to start a stopped instance
+    # https://github.com/hashicorp/terraform-provider-aws/issues/40785
+    - name: Start DB
+      if: ${{ inputs.state != 'stopped' }}
+      shell: bash
+      run: |
+        # start the db if it is in a "stopped" state
+        if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
+        then
+          aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
+        fi
+        while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
+        do
+          echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
+          sleep 30
+        done
+        echo "DB successfully started!"
 
     # - name: Stop DB
     #   if: ${{ inputs.state == 'stopped' }}

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -65,7 +65,7 @@ runs:
         # start the db if it is in a "stopped" state
         if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
         then
-          aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }}
+          aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
         fi
         while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
         do
@@ -81,7 +81,7 @@ runs:
         # stop the db if it is in the "available" state
         if [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") == "available" ]
         then
-          aws rds stop-db-instance --db-instance-identifier graasp-${{ inputs.environment }}
+          aws rds stop-db-instance --db-instance-identifier graasp-${{ inputs.environment }} | jq -r ".DBInstance.DBInstanceStatus"
         fi
         while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "stopped" ]
         do

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -52,7 +52,6 @@ runs:
   using: composite
   steps:
     - name: Configure AWS Credentials to assume terraform Role
-      id: configure-aws-assume-role
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.aws-role-to-assume }}
@@ -108,7 +107,6 @@ runs:
       shell: bash
 
     - name: Configure AWS Credentials for terraform user
-      id: configure-aws-user
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
@@ -129,3 +127,21 @@ runs:
         TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ inputs.graasp-db-gatekeeper-key-name }}
         TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ inputs.gatekeeper-ami-id }}
         TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ inputs.gatekeeper-instance-type }}
+
+    - name: Configure AWS Credentials to assume terraform Role
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        role-session-name: GitHub_Action_deploy_infrastructure
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Invalidate Cloudfront distributions
+      shell: bash
+      # invalidate all cloudfront distributions
+      # 1. get the distribution ids by calling "list-distributions" command
+      # 2. pipe result to jq and return one distribution id per line
+      # 3. use xargs to execute the invalidation call for each of the distribution Id in input, invalidating the whole bucket
+      run: |
+        aws cloudfront list-distributions \
+        | jq -c ".DistributionList.Items.[].Id" \
+        | xargs -L 1 -I {} aws cloudfront create-invalidation --distribution-id {} --paths '/'

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -20,6 +20,33 @@ inputs:
   aws-secret-access-key:
     description: "AWS secret key"
     required: true
+  maintenance-header-name:
+    description: "Maintenance header name"
+    required: true
+  maintenance-header-secret:
+    description: "Maintenance header value"
+    required: true
+  tf-var-meilisearch-master-key:
+    description: "Meilisearch master key"
+    required: true
+  tf-var-graasp-db-password:
+    description: "Graasp DB password"
+    required: true
+  tf-var-etherpad-db-password:
+    description: "Etherpad DB password"
+    required: true
+  tf-var-umami-db-password:
+    description: "Umami DB password"
+    required: true
+  tf-var-graasp-db-gatekeeper-key-name:
+    description: "Gatekeeper key name for auth"
+    required: true
+  tf-var-db-gatekeeper-ami-id:
+    description: "Gatekeeper AMI for machine setup"
+    required: true
+  tf-var-db-gatekeeper-instance-type:
+    description: "Gatekeeper instance type"
+    required: true
 
 runs:
   using: composite
@@ -93,12 +120,12 @@ runs:
       shell: bash
       env:
         INFRA_STATE: ${{ inputs.state }}
-        MAINTENANCE_HEADER_NAME: ${{ secrets.MAINTENANCE_HEADER_NAME }}
-        MAINTENANCE_HEADER_SECRET: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
-        TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
-        TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
-        TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
-        TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
-        TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
-        TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
-        TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}
+        MAINTENANCE_HEADER_NAME: ${{ inputs.maintenance-header-name }}
+        MAINTENANCE_HEADER_SECRET: ${{ inputs.maintenance-header-secret }}
+        TF_VAR_MEILISEARCH_MASTER_KEY: ${{ inputs.tf-meilisearch-master-key }}
+        TF_VAR_GRAASP_DB_PASSWORD: ${{ inputs.tf-graasp-db-password }}
+        TF_VAR_ETHERPAD_DB_PASSWORD: ${{ inputs.tf-etherpad-db-password }}
+        TF_VAR_UMAMI_DB_PASSWORD: ${{ inputs.tf-var-umami-db-password }}
+        TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ inputs.tf-graasp-db-gatekeeper-key-name }}
+        TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ inputs.tf-db-gatekeeper-ami-id }}
+        TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ inputs.tf-db-gatekeeper-instance-type }}

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -1,0 +1,107 @@
+name: Composite terraform CDK deploy workflow
+description: Deploy the infrastructure in a specific state
+
+inputs:
+  state:
+    description: "Infra state"
+    required: true
+  environment:
+    description: "Environment to target"
+    required: true
+  aws-role-to-assume:
+    description: "AWS Role to assume to start/stop the DB"
+    required: true
+  aws-region:
+    description: "AWS Region for for the deployment"
+    required: true
+  aws-access-key-id:
+    description: "AWS Key id"
+    required: true
+  aws-secret-access-key:
+    description: "AWS secret key"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure AWS Credentials to assume terraform Role
+      id: configure-aws-assume-role
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        role-session-name: GitHub_Action_deploy_infrastructure
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Start DB
+      if: ${{ inputs.state != 'stopped' }}
+      shell: bash
+      run: |
+        # start the db if it is in a "stopped" state
+        if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
+        then
+          aws rds start-db-instance --db-instance-identifier graasp-${{ inputs.environment }}
+        fi
+        while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
+        do
+          echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
+          sleep 30
+        done
+        echo "DB successfully started!"
+
+    - name: Stop DB
+      if: ${{ inputs.state == 'stopped' }}
+      shell: bash
+      run: |
+        # stop the db if it is in the "available" state
+        if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "available" ]
+        then
+          aws rds stop-db-instance --db-instance-identifier graasp-${{ inputs.environment }}
+        fi
+        while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "stopped" ]
+        do
+          echo "waiting for DB to be down $(date -u +%H:%M:%S) (UTC)"
+          sleep 30
+        done
+        echo "DB successfully stopped!"
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "22"
+
+    - name: Install dependencies
+      run: yarn install
+      shell: bash
+
+    - name: Generate module and provider bindings
+      run: npx cdktf get
+      shell: bash
+
+    - name: Configure AWS Credentials for terraform user
+      id: configure-aws-user
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Deploy Infra as "${{inputs.state }}" state to ${{ inputs.environment }} environment
+      run: npx cdktf deploy --auto-approve 'graasp-${{ inputs.environment }}'
+      shell: bash
+      env:
+        INFRA_STATE: ${{ inputs.state }}
+        MAINTENANCE_HEADER_NAME: ${{ secrets.MAINTENANCE_HEADER_NAME }}
+        MAINTENANCE_HEADER_SECRET: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
+        TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
+        TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
+        TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+        TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
+        TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
+        TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
+        TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -33,3 +33,12 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
+          maintenance-header-name: ${{ secrets.MAINTENANCE_HEADER_NAME }}
+          maintenance-header-secret: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
+          tf-var-meilisearch-master-key: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
+          tf-var-graasp-db-password: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
+          tf-var-etherpad-db-password: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+          tf-var-umami-db-password: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
+          tf-var-graasp-db-gatekeeper-key-name: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
+          tf-var-db-gatekeeper-ami-id: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
+          tf-var-db-gatekeeper-instance-type: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -35,10 +35,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
           maintenance-header-name: ${{ secrets.MAINTENANCE_HEADER_NAME }}
           maintenance-header-secret: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
-          tf-var-meilisearch-master-key: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
-          tf-var-graasp-db-password: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
-          tf-var-etherpad-db-password: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
-          tf-var-umami-db-password: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
-          tf-var-graasp-db-gatekeeper-key-name: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
-          tf-var-db-gatekeeper-ami-id: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
-          tf-var-db-gatekeeper-instance-type: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}
+          meilisearch-master-key: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
+          graasp-db-password: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
+          etherpad-db-password: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+          umami-db-password: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
+          graasp-db-gatekeeper-key-name: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
+          gatekeeper-ami-id: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
+          gatekeeper-instance-type: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -1,4 +1,4 @@
-name: Auto-start dev infra
+name: Start dev infra
 on:
   schedule:
     - cron: "30 7 * * *"

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Deploy Infra
         uses: ./.github/actions/deploy-infra
         with:

--- a/.github/workflows/infra-start.yml
+++ b/.github/workflows/infra-start.yml
@@ -18,71 +18,15 @@ jobs:
   deploy:
     name: "Deploy infra in running state to ${{ inputs.environment || 'dev' }} environment"
     environment: ${{ inputs.environment || 'dev' }}
-    env:
-      state: "running"
-      environment: ${{ inputs.environment || 'dev' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure AWS Credentials
-        id: configure-aws
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Deploy Infra
+        uses: ./.github/actions/deploy-infra
         with:
-          role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}
-          role-session-name: GitHub_Action_deploy_infrastructure
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Start DB
-        if: ${{ env.state != 'stopped' }}
-        run: |
-          # start the db if it is in a "stopped" state
-          if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "stopped" ]
-          then
-            aws rds start-db-instance --db-instance-identifier graasp-${{ env.environment }}
-          fi
-          while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "available" ]
-          do
-            echo "waiting for DB to be up $(date -u +%H:%M:%S) (UTC)"
-            sleep 30
-          done
-          echo "DB successfully started!"
-
-      - name: Stop DB
-        if: ${{ env.state == 'stopped' }}
-        run: |
-          # stop the db if it is in the "available" state
-          if [ $(aws rds describe-db-instances | jq ".DBInstances.[0].DBInstanceStatus") == "available" ]
-          then
-            aws rds stop-db-instance --db-instance-identifier graasp-${{ env.environment }}
-          fi
-          while [ $(aws rds describe-db-instances | jq -r ".DBInstances.[0].DBInstanceStatus") != "stopped" ]
-          do
-            echo "waiting for DB to be down $(date -u +%H:%M:%S) (UTC)"
-            sleep 30
-          done
-          echo "DB successfully stopped!"
-
-      - name: Prepare terraform
-        uses: ./.github/actions/prepare-terraform
-        with:
+          state: "running"
+          environment: ${{ inputs.environment || 'dev' }}
+          aws-role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
-
-      - name: Deploy
-        run: npx cdktf deploy --auto-approve 'graasp-${{ env.environment }}'
-        shell: bash
-        env:
-          INFRA_STATE: ${{ env.state }}
-          MAINTENANCE_HEADER_NAME: ${{ secrets.MAINTENANCE_HEADER_NAME }}
-          MAINTENANCE_HEADER_SECRET: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
-          TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
-          TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
-          TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
-          TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
-          TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
-          TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
-          TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/.github/workflows/infra-stop.yml
+++ b/.github/workflows/infra-stop.yml
@@ -1,4 +1,4 @@
-name: Stop Infra
+name: Stop dev infra
 on:
   schedule:
     - cron: "30 18 * * *"

--- a/.github/workflows/infra-stop.yml
+++ b/.github/workflows/infra-stop.yml
@@ -1,52 +1,43 @@
 name: Stop Infra
 on:
   schedule:
-    - cron: "30 19 * * *"
+    - cron: "30 18 * * *"
   workflow_dispatch:
     inputs:
       environment:
         description: "Target environment"
         type: environment
         required: true
-      state:
-        description: "Expected infrastructure state"
-        type: choice
-        options:
-          - running
-          - restricted
-          - db-only
-          - stopped
-        required: false
-        # default to stopped - only for the manual select
-        default: stopped
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
 
 jobs:
   deploy:
-    name: "Deploy infra in ${{ inputs.state || 'stopped' }} state to ${{ inputs.environment || 'dev' }} environment"
+    name: "Deploy infra in stopped state to ${{ inputs.environment || 'dev' }} environment"
     environment: ${{ inputs.environment || 'dev' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare terraform
-        uses: ./.github/actions/prepare-terraform
+      - name: Deploy Infra
+        uses: ./.github/actions/deploy-infra
         with:
+          state: "stopped"
+          environment: ${{ inputs.environment || 'dev' }}
+          aws-role-to-assume: ${{ secrets.TF_AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
-
-      - name: Deploy
-        run: npx cdktf deploy --auto-approve 'graasp-${{ inputs.environment || 'dev' }}'
-        shell: bash
-        env:
-          INFRA_STATE: ${{ inputs.state || 'stopped' }}
-          MAINTENANCE_HEADER_NAME: ${{ secrets.MAINTENANCE_HEADER_NAME }}
-          MAINTENANCE_HEADER_SECRET: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
-          TF_VAR_MEILISEARCH_MASTER_KEY: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
-          TF_VAR_GRAASP_DB_PASSWORD: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
-          TF_VAR_ETHERPAD_DB_PASSWORD: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
-          TF_VAR_UMAMI_DB_PASSWORD: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
-          TF_VAR_GRAASP_DB_GATEKEEPER_KEY_NAME: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
-          TF_VAR_DB_GATEKEEPER_AMI_ID: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
-          TF_VAR_DB_GATEKEEPER_INSTANCE_TYPE: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}
+          maintenance-header-name: ${{ secrets.MAINTENANCE_HEADER_NAME }}
+          maintenance-header-secret: ${{ secrets.MAINTENANCE_HEADER_SECRET }}
+          meilisearch-master-key: ${{ secrets.TF_MEILISEARCH_MASTER_KEY }}
+          graasp-db-password: ${{ secrets.TF_GRAASP_DB_PASSWORD }}
+          etherpad-db-password: ${{ secrets.TF_ETHERPAD_DB_PASSWORD }}
+          umami-db-password: ${{ secrets.TF_VAR_UMAMI_DB_PASSWORD }}
+          graasp-db-gatekeeper-key-name: ${{ secrets.TF_GRAASP_DB_GATEKEEPER_KEY_NAME }}
+          gatekeeper-ami-id: ${{ vars.TF_DB_GATEKEEPER_AMI_ID }}
+          gatekeeper-instance-type: ${{ vars.TF_DB_GATEKEEPER_INSTANCE_TYPE }}

--- a/constructs/postgres.ts
+++ b/constructs/postgres.ts
@@ -135,6 +135,9 @@ export class PostgresDB extends Construct {
     // manage instance state based on the `isActive` param
     new RdsInstanceState(this, `${this.instance.identifier}-instance-state`, {
       identifier: this.instance.identifier,
+      // A bug makes it impossible to activate a database in the "stopped" state.
+      // The state of the db is expected to be "available" before performing the state change...
+      // Bur report tracking the issue: https://github.com/hashicorp/terraform-provider-aws/issues/40785
       state: isActive ? 'available' : 'stopped',
     });
   }


### PR DESCRIPTION
In this PR:
- make a composite workflow with all steps needed to apply a specific state to the infra.
- find a bug that makes it impossible to activate a db that is in the "stopped" state with terraform.

For reference, the tracker for the `aws_db_instance_state`: https://github.com/hashicorp/terraform-provider-aws/issues/40785

The bug is essentially that the state of the database is expected to be "available" before any state change is performed. Which will obviously fail if you want a transition `stopped -> available`. 