### PR TITLE
fix: header name for maintenance

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -130,7 +130,7 @@ class GraaspStack extends TerraformStack {
     const maintenanceHeaderRule = maintenanceHeaderValues
       ? ({
           httpHeader: {
-            httpHeaderName: maintenanceHeaderValues.name,
+            httpHeaderName: `x-maintenance-${maintenanceHeaderValues.name}`,
             values: [maintenanceHeaderValues.value],
           },
         } satisfies LbListenerRuleCondition)


### PR DESCRIPTION
In this PR I update the name of the header used for the load balancer to match what is used in the cloudfront function: `x-maintenance-XXXXXX`.