### PR TITLE
fix: make umami stay up during migration and maintenance

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -32,8 +32,8 @@ import {
   GraaspWebsiteConfig,
   buildPostgresConnectionString,
   envDomain,
-  getInfraState,
   getMaintenanceHeaderPair,
+  isServiceActive,
   subdomainForEnv,
   validateInfraState,
 } from './utils';
@@ -376,7 +376,7 @@ class GraaspStack extends TerraformStack {
         migrationServiceAllowedSecurityGroupInfo,
       ],
       CONFIG[environment.env].dbConfig.graasp.enableReplication,
-      getInfraState(environment).isDatabaseActive,
+      isServiceActive(environment).database,
       CONFIG[environment.env].dbConfig.graasp.backupRetentionPeriod,
       undefined,
       gatekeeper.instance.securityGroup,
@@ -493,8 +493,7 @@ class GraaspStack extends TerraformStack {
       environment,
     );
 
-    const graaspServicesActive =
-      getInfraState(environment).areGraaspServicesActive;
+    const graaspServicesActive = isServiceActive(environment).graasp;
     // backend
     cluster.addService(
       'graasp',
@@ -586,7 +585,7 @@ class GraaspStack extends TerraformStack {
         memory: CONFIG[environment.env].ecsConfig.umami.memory,
         dummy: false,
       },
-      getInfraState(environment).isUmamiActive,
+      isServiceActive(environment).umami,
       umamiSecurityGroup,
       { name: 'umami', port: UMAMI_PORT },
       undefined,
@@ -663,7 +662,7 @@ class GraaspStack extends TerraformStack {
     cluster.addOneOffTask(
       'migrate',
       1,
-      getInfraState(environment).isMigrationActive,
+      isServiceActive(environment).migration,
       {
         containerDefinitions: migrateDefinition,
         cpu: CONFIG[environment.env].ecsConfig.migrate.cpu,

--- a/main.ts
+++ b/main.ts
@@ -493,7 +493,8 @@ class GraaspStack extends TerraformStack {
       environment,
     );
 
-    const servicesActive = getInfraState(environment).areServicesActive;
+    const graaspServicesActive =
+      getInfraState(environment).areGraaspServicesActive;
     // backend
     cluster.addService(
       'graasp',
@@ -504,7 +505,7 @@ class GraaspStack extends TerraformStack {
         memory: CONFIG[environment.env].ecsConfig.graasp.memory,
         dummy: true,
       },
-      servicesActive,
+      graaspServicesActive,
       backendSecurityGroup,
       undefined,
       {
@@ -530,7 +531,7 @@ class GraaspStack extends TerraformStack {
       'graasp-library',
       1,
       { containerDefinitions: libraryDummyBackendDefinition, dummy: true },
-      servicesActive,
+      graaspServicesActive,
       librarySecurityGroup,
       undefined,
       {
@@ -561,7 +562,7 @@ class GraaspStack extends TerraformStack {
         memory: CONFIG[environment.env].ecsConfig.etherpad.memory,
         dummy: false,
       },
-      servicesActive,
+      graaspServicesActive,
       etherpadSecurityGroup,
       undefined,
       undefined,
@@ -585,7 +586,7 @@ class GraaspStack extends TerraformStack {
         memory: CONFIG[environment.env].ecsConfig.umami.memory,
         dummy: false,
       },
-      servicesActive,
+      getInfraState(environment).isUmamiActive,
       umamiSecurityGroup,
       { name: 'umami', port: UMAMI_PORT },
       undefined,
@@ -609,7 +610,7 @@ class GraaspStack extends TerraformStack {
         memory: CONFIG[environment.env].ecsConfig.meilisearch.memory,
         dummy: false,
       },
-      servicesActive,
+      graaspServicesActive,
       meilisearchSecurityGroup,
       { name: 'graasp-meilisearch', port: MEILISEARCH_PORT },
     );
@@ -623,7 +624,7 @@ class GraaspStack extends TerraformStack {
         memory: CONFIG[environment.env].ecsConfig.iframely.memory,
         dummy: false,
       },
-      servicesActive,
+      graaspServicesActive,
       iframelySecurityGroup,
       { name: 'graasp-iframely', port: IFRAMELY_PORT },
     );
@@ -637,7 +638,7 @@ class GraaspStack extends TerraformStack {
         memory: CONFIG[environment.env].ecsConfig.redis.memory,
         dummy: false,
       },
-      servicesActive,
+      graaspServicesActive,
       redisSecurityGroup,
       { name: 'graasp-redis', port: REDIS_PORT },
     );

--- a/utils.ts
+++ b/utils.ts
@@ -86,7 +86,8 @@ export function validateInfraState(
 export function getInfraState(environment: EnvironmentConfig): {
   isMaintenanceActive: boolean;
   isDatabaseActive: boolean;
-  areServicesActive: boolean;
+  isUmamiActive: boolean;
+  areGraaspServicesActive: boolean;
   isMigrationActive: boolean;
 } {
   const { infraState } = environment;
@@ -95,21 +96,24 @@ export function getInfraState(environment: EnvironmentConfig): {
       return {
         isMaintenanceActive: true,
         isDatabaseActive: false,
-        areServicesActive: false,
+        isUmamiActive: false,
+        areGraaspServicesActive: false,
         isMigrationActive: false,
       };
     case InfraState.DBOnly:
       return {
         isMaintenanceActive: true,
         isDatabaseActive: true,
-        areServicesActive: false,
+        isUmamiActive: true,
+        areGraaspServicesActive: false,
         isMigrationActive: true,
       };
     case InfraState.Restricted:
       return {
         isMaintenanceActive: true,
         isDatabaseActive: true,
-        areServicesActive: true,
+        isUmamiActive: true,
+        areGraaspServicesActive: true,
         isMigrationActive: false,
       };
     case InfraState.Running:
@@ -117,7 +121,8 @@ export function getInfraState(environment: EnvironmentConfig): {
       return {
         isMaintenanceActive: false,
         isDatabaseActive: true,
-        areServicesActive: true,
+        isUmamiActive: true,
+        areGraaspServicesActive: true,
         isMigrationActive: false,
       };
   }

--- a/utils.ts
+++ b/utils.ts
@@ -83,47 +83,47 @@ export function validateInfraState(
   return infraState as InfraStateOptions;
 }
 
-export function getInfraState(environment: EnvironmentConfig): {
-  isMaintenanceActive: boolean;
-  isDatabaseActive: boolean;
-  isUmamiActive: boolean;
-  areGraaspServicesActive: boolean;
-  isMigrationActive: boolean;
+export function isServiceActive(environment: EnvironmentConfig): {
+  maintenance: boolean;
+  database: boolean;
+  umami: boolean;
+  graasp: boolean;
+  migration: boolean;
 } {
   const { infraState } = environment;
   switch (infraState) {
     case InfraState.Stopped:
       return {
-        isMaintenanceActive: true,
-        isDatabaseActive: false,
-        isUmamiActive: false,
-        areGraaspServicesActive: false,
-        isMigrationActive: false,
+        maintenance: true,
+        database: false,
+        umami: false,
+        graasp: false,
+        migration: false,
       };
     case InfraState.DBOnly:
       return {
-        isMaintenanceActive: true,
-        isDatabaseActive: true,
-        isUmamiActive: true,
-        areGraaspServicesActive: false,
-        isMigrationActive: true,
+        maintenance: true,
+        database: true,
+        umami: true,
+        graasp: false,
+        migration: true,
       };
     case InfraState.Restricted:
       return {
-        isMaintenanceActive: true,
-        isDatabaseActive: true,
-        isUmamiActive: true,
-        areGraaspServicesActive: true,
-        isMigrationActive: false,
+        maintenance: true,
+        database: true,
+        umami: true,
+        graasp: true,
+        migration: false,
       };
     case InfraState.Running:
     default:
       return {
-        isMaintenanceActive: false,
-        isDatabaseActive: true,
-        isUmamiActive: true,
-        areGraaspServicesActive: true,
-        isMigrationActive: false,
+        maintenance: false,
+        database: true,
+        umami: true,
+        graasp: true,
+        migration: false,
       };
   }
 }
@@ -131,7 +131,7 @@ export function getInfraState(environment: EnvironmentConfig): {
 export function getMaintenanceHeaderPair(
   environment: EnvironmentConfig,
 ): { name: string; value: string } | undefined {
-  if (getInfraState(environment).isMaintenanceActive === false) {
+  if (isServiceActive(environment).maintenance === false) {
     return undefined;
   }
   const name = process.env.MAINTENANCE_HEADER_NAME;


### PR DESCRIPTION
We want Umami to stay up when doing maintenance and migration.

This PR makes the necessary changes for this.
close #59 