### PR TITLE
fix: deploy core and workers image

### DIFF
--- a/.github/workflows/deploy-core-version.yml
+++ b/.github/workflows/deploy-core-version.yml
@@ -57,15 +57,18 @@ jobs:
       - name: Deploy new core version
         run: |
           private_ecr_uri=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
-          core_image_tag=core-${{ inputs.version }}
-          public_ecr_image=docker://${{ vars.AWS_PUBLIC_ECR_URI }}/graasp:$core_image_tag
-          image_tag=docker://$private_ecr_uri/graasp:core-latest
 
           # login the skopeo client with the ECR credentials derived from the currently authenticated user
-          aws ecr get-login-password --region ${{ vars.AWS_REGION }} | skopeo login --username AWS --password-stdin $private_ecr_uri
+          aws ecr get-login-password --region ${{ vars.AWS_REGION }} | skopeo login --username AWS --password-stdin "$private_ecr_uri"
 
-          # copy
-          skopeo --override-os linux copy $public_ecr_image $image_tag
+          for prefix in core workers; do
+            image_tag=${prefix}-${{ inputs.version }}
+            public_ecr_image=docker://${{ vars.AWS_PUBLIC_ECR_URI }}/graasp:$image_tag
+            private_ecr_image=docker://$private_ecr_uri/graasp:${prefix}-latest
+
+            echo "Copying $public_ecr_image to $private_ecr_image"
+            skopeo --override-os linux copy "$public_ecr_image" "$private_ecr_image"
+          done
 
       - name: Deploy Infra
         uses: ./.github/actions/deploy-infra

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -122,13 +122,19 @@ jobs:
           exit 1;
           fi
 
-      - name: Copy nightly to latest for core
+      - name: Copy nightly to latest for core and workers
         run: |
-          private_ecr_uri=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
-          # login the skopeo client with the ECR credentials derived from the currently authenticated user
-          aws ecr get-login-password --region ${{ vars.AWS_REGION }} | skopeo login --username AWS --password-stdin $private_ecr_uri
-          # copy
-          skopeo --override-os linux copy docker://$private_ecr_uri/graasp:core-nightly docker://$private_ecr_uri/graasp:core-latest
+          private_ecr_uri="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com"
+
+          # Login the skopeo client with the ECR credentials derived from the currently authenticated user
+          aws ecr get-login-password --region "${{ vars.AWS_REGION }}" | skopeo login --username AWS --password-stdin "$private_ecr_uri"
+
+          for prefix in core workers; do
+            src="docker://$private_ecr_uri/graasp:${prefix}-nightly"
+            dest="docker://$private_ecr_uri/graasp:${prefix}-latest"
+            echo "Copying $src to $dest"
+            skopeo --override-os linux copy "$src" "$dest"
+          done
 
       - name: Deploy Infra
         uses: ./.github/actions/deploy-infra


### PR DESCRIPTION
This pull request updates the deployment workflows to deploy both the core and workers Docker images. The workflows now use loops to handle both images, ensuring they are tagged as latest in the private ECR.