### PR TITLE
feat: allow compressed client

### DIFF
--- a/constructs/graasp_distribution.ts
+++ b/constructs/graasp_distribution.ts
@@ -133,6 +133,7 @@ export function createClientStack(
         viewerProtocolPolicy: 'redirect-to-https',
         allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
         cachedMethods: ['GET', 'HEAD'],
+        compress: true,
         functionAssociation: props.functionAssociationArn
           ? [
               {


### PR DESCRIPTION
Allow cloudfront to compress the client when possible.

We could add it to the other s3 buckets but I couldn't see a difference when manually applying, so we can keep that for later.