### PR TITLE
fix: allow admin to write on files and h5p buckets

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -863,9 +863,12 @@ class GraaspStack extends TerraformStack {
       .allowECSExec()
       .allowS3Access(
         { arn: fileItemBucket.bucket.arn, name: 'files' },
-        { read: true },
+        { read: true, write: true },
       )
-      .allowS3Access({ arn: h5pBucket.bucket.arn, name: 'h5p' }, { read: true })
+      .allowS3Access(
+        { arn: h5pBucket.bucket.arn, name: 'h5p' },
+        { read: true, write: true },
+      )
       .allowSESAccess();
 
     const libraryDefinition = createContainerDefinitions(


### PR DESCRIPTION
In this PR, I allow admin to write to the s3 bucket.

This allows it to upload files and delete files.