### PR TITLE
fix: use yarn and mise in CI

### DIFF
--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -181,10 +181,8 @@ runs:
       with:
         terraform_version: '1.14.9'
 
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: '22'
+    - name: Install Mise
+      uses: jdx/mise-action@v3
 
     - name: Install dependencies
       run: yarn install

--- a/.github/actions/deploy-infra/action.yml
+++ b/.github/actions/deploy-infra/action.yml
@@ -189,7 +189,7 @@ runs:
       shell: bash
 
     - name: Generate module and provider bindings
-      run: npx cdktf get
+      run: yarn cdktf get
       shell: bash
 
     - name: Configure AWS Credentials for terraform user
@@ -200,7 +200,7 @@ runs:
         aws-region: ${{ inputs.aws-region }}
 
     - name: Deploy Infra as "${{inputs.state }}" state to ${{ inputs.environment }} environment
-      run: npx cdktf deploy --auto-approve 'graasp-${{ inputs.environment }}'
+      run: yarn cdktf deploy --auto-approve 'graasp-${{ inputs.environment }}'
       shell: bash
       env:
         INFRA_STATE: ${{ inputs.state }}

--- a/.github/actions/prepare-terraform/action.yml
+++ b/.github/actions/prepare-terraform/action.yml
@@ -19,9 +19,8 @@ runs:
       with:
         terraform_version: '1.14.9'
 
-    - uses: actions/setup-node@v6
-      with:
-        node-version: '22'
+    - name: Install Mise
+      uses: jdx/mise-action@v3
 
     - name: Install dependencies
       run: yarn install

--- a/.github/actions/prepare-terraform/action.yml
+++ b/.github/actions/prepare-terraform/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
 
     - name: Generate module and provider bindings
-      run: npx cdktf get
+      run: yarn cdktf get
       shell: bash
 
     - name: Configure AWS Credentials

--- a/.github/workflows/infrastructure-deploy-env.yml
+++ b/.github/workflows/infrastructure-deploy-env.yml
@@ -37,7 +37,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
       - name: Plan
-        run: npx cdktf plan graasp-${{ inputs.environment }}
+        run: yarn cdktf plan graasp-${{ inputs.environment }}
         shell: bash
         env:
           INFRA_STATE: ${{ inputs.state }}
@@ -94,7 +94,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.TF_SECRET_AWS_ACCESS_KEY }}
 
       - name: Deploy
-        run: npx cdktf deploy --auto-approve 'graasp-${{ inputs.environment }}'
+        run: yarn cdktf deploy --auto-approve 'graasp-${{ inputs.environment }}'
         shell: bash
         env:
           INFRA_STATE: ${{ inputs.state }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,12 @@
+[tools]
+node = "22"
+
+
+[hooks]
+# Enabling corepack will install the `pnpm` package manager specified in your package.json
+# alternatively, you can also install `pnpm` with mise
+postinstall = 'npx corepack enable'
+
+[settings]
+# This must be enabled to make the hooks work
+experimental = true


### PR DESCRIPTION
In this PR: 
- use mise for node version management 
- use `yarn` instead of `npx` to use package specific version of cdktf

fix #127 